### PR TITLE
Add load testing tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: loadtest
+loadtest:
+	k6 run loadtest/search.js --summary-export=loadtest/results/search/`date +%Y%m%d`.json

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -1,0 +1,3 @@
+# loadtest
+
+Requires k6, cf https://k6.io/docs/getting-started/installation for installation instructions.

--- a/loadtest/results/search/20201130.json
+++ b/loadtest/results/search/20201130.json
@@ -1,0 +1,121 @@
+{
+    "metrics": {
+        "checks": {
+            "fails": 0,
+            "passes": 6614,
+            "value": 0
+        },
+        "data_received": {
+            "count": 427057317,
+            "rate": 7096024.607770866
+        },
+        "data_sent": {
+            "count": 486129,
+            "rate": 8077.565257009853
+        },
+        "http_req_blocked": {
+            "avg": 0.20448866041729621,
+            "max": 38.659,
+            "med": 0.003,
+            "min": 0.001,
+            "p(90)": 0.005,
+            "p(95)": 0.006
+        },
+        "http_req_connecting": {
+            "avg": 0.19618808587843978,
+            "max": 38.587,
+            "med": 0,
+            "min": 0,
+            "p(90)": 0,
+            "p(95)": 0
+        },
+        "http_req_duration": {
+            "avg": 180.93188962806198,
+            "max": 377.676,
+            "med": 176.215,
+            "min": 90.665,
+            "p(90)": 235.607,
+            "p(95)": 257.32899999999995
+        },
+        "http_req_receiving": {
+            "avg": 15.030185969156346,
+            "max": 172.363,
+            "med": 12.525,
+            "min": 0.124,
+            "p(90)": 28.1572,
+            "p(95)": 36.8531
+        },
+        "http_req_sending": {
+            "avg": 0.021806471121862982,
+            "max": 0.139,
+            "med": 0.02,
+            "min": 0.007,
+            "p(90)": 0.029400000000000093,
+            "p(95)": 0.042
+        },
+        "http_req_tls_handshaking": {
+            "avg": 0,
+            "max": 0,
+            "med": 0,
+            "min": 0,
+            "p(90)": 0,
+            "p(95)": 0
+        },
+        "http_req_waiting": {
+            "avg": 165.8798971877834,
+            "max": 364.677,
+            "med": 162.484,
+            "min": 80.921,
+            "p(90)": 214.67380000000003,
+            "p(95)": 232.9855
+        },
+        "http_reqs": {
+            "count": 3307,
+            "rate": 54.949423517073825
+        },
+        "iteration_duration": {
+            "avg": 181.709490421228,
+            "max": 378.434362,
+            "med": 176.775126,
+            "min": 91.23101,
+            "p(90)": 236.7519174,
+            "p(95)": 258.6880064
+        },
+        "iterations": {
+            "count": 3307,
+            "rate": 54.949423517073825
+        },
+        "vus": {
+            "max": 10,
+            "min": 10,
+            "value": 10
+        },
+        "vus_max": {
+            "max": 10,
+            "min": 10,
+            "value": 10
+        }
+    },
+    "root_group": {
+        "name": "",
+        "path": "",
+        "id": "d41d8cd98f00b204e9800998ecf8427e",
+        "groups": {},
+        "checks": {
+            "response body": {
+                "name": "response body",
+                "path": "::response body",
+                "id": "e4c5bc207f62565049bed5e0093b366b",
+                "passes": 3307,
+                "fails": 0
+            },
+            "status is 200": {
+                "name": "status is 200",
+                "path": "::status is 200",
+                "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
+                "passes": 3307,
+                "fails": 0
+            }
+        }
+    }
+}

--- a/loadtest/search.js
+++ b/loadtest/search.js
@@ -1,0 +1,21 @@
+import http from 'k6/http';
+import { check } from 'k6';
+import { Counter } from 'k6/metrics';
+
+// A simple counter for http requests
+export const requests = new Counter('http_reqs');
+
+export let options = {
+  vus: 10,
+  duration: '1m',
+  // iterations: 10000
+};
+
+export default function () {
+  const q = 'la%20poste';
+  const res = http.get(`http://recherche.entreprise.dataeng.etalab.studio/search?q=${q}&page=1&per_page=100`);
+  const checkRes = check(res, {
+    'status is 200': (r) => r.status === 200,
+    'response body': (r) => r.body.indexOf('unite_legale') !== -1,
+  });
+}


### PR DESCRIPTION
Proposal for load testing. It uses https://k6.io. 

I added a simple script to benchmark the search endpoint: as many requests as possible for a minute with 10 concurrent users.

I like the fact that we can persist the results (cf `loadtest/results/search`) and compare them over time. We probably should run those on a CI though, or a designated server to avoid factors linked to local setup.

Use `make loadtest` to give it a try, after installing k6.